### PR TITLE
syncer: adapt region history buffer size

### DIFF
--- a/pkg/syncer/history_buffer.go
+++ b/pkg/syncer/history_buffer.go
@@ -19,6 +19,7 @@ import (
 
 	"go.uber.org/zap"
 
+	"github.com/pingcap/errors"
 	"github.com/pingcap/log"
 
 	"github.com/tikv/pd/pkg/core"
@@ -28,8 +29,11 @@ import (
 )
 
 const (
-	historyKey        = "historyIndex"
-	defaultFlushCount = 100
+	historyKey                = "historyIndex"
+	defaultFlushCount         = 100
+	historyBufferCapacityUnit = 10000
+	historyBufferGrowFactor   = 8
+	historyBufferShrinkRounds = 3
 )
 
 var (
@@ -39,32 +43,72 @@ var (
 	lastIndexGauge  = regionSyncerStatus.WithLabelValues("last_index")
 )
 
+var errHistoryBufferRetainOverflow = errors.New("history buffer retained range exceeds maximum capacity")
+
 type historyBuffer struct {
 	syncutil.RWMutex
-	index      uint64
-	records    []*core.RegionInfo
-	head       int
-	tail       int
-	size       int
-	kv         kv.Base
-	flushCount int
+	index                  uint64
+	records                []*core.RegionInfo
+	head                   int
+	tail                   int
+	size                   int
+	baseCapacity           int
+	maxCapacity            int
+	capacityUnit           int
+	retains                map[uint64]uint64
+	nextRetainID           uint64
+	retainOverflow         bool
+	observedRequiredWindow uint64
+	lowWindowRounds        int
+	kv                     kv.Base
+	flushCount             int
+}
+
+type historyRetainer struct {
+	h  *historyBuffer
+	id uint64
 }
 
 func newHistoryBuffer(size int, kv kv.Base) *historyBuffer {
+	baseCapacity := normalizeHistoryBufferCapacity(size, historyBufferCapacityUnit)
+	return newHistoryBufferWithConfig(baseCapacity, baseCapacity*historyBufferGrowFactor, historyBufferCapacityUnit, kv)
+}
+
+func newHistoryBufferWithConfig(baseCapacity, maxCapacity, capacityUnit int, kv kv.Base) *historyBuffer {
+	baseCapacity = normalizeHistoryBufferCapacity(baseCapacity, capacityUnit)
+	maxCapacity = normalizeHistoryBufferCapacity(maxCapacity, capacityUnit)
+	if maxCapacity < baseCapacity {
+		maxCapacity = baseCapacity
+	}
 	// use an empty space to simplify operation
-	size++
+	size := baseCapacity + 1
 	if size < 2 {
 		size = 2
 	}
 	records := make([]*core.RegionInfo, size)
 	h := &historyBuffer{
-		records:    records,
-		size:       size,
-		kv:         kv,
-		flushCount: defaultFlushCount,
+		records:      records,
+		size:         size,
+		baseCapacity: baseCapacity,
+		maxCapacity:  maxCapacity,
+		capacityUnit: capacityUnit,
+		retains:      make(map[uint64]uint64),
+		kv:           kv,
+		flushCount:   defaultFlushCount,
 	}
 	h.reload()
 	return h
+}
+
+func normalizeHistoryBufferCapacity(size, capacityUnit int) int {
+	if capacityUnit <= 0 {
+		capacityUnit = historyBufferCapacityUnit
+	}
+	capacity := capacityUnit
+	for capacity < size {
+		capacity *= 2
+	}
+	return capacity
 }
 
 func (h *historyBuffer) len() int {
@@ -86,9 +130,20 @@ func (h *historyBuffer) firstIndex() uint64 {
 	return h.index - uint64(h.len())
 }
 
+func (h *historyBuffer) capacity() int {
+	return h.size - 1
+}
+
 func (h *historyBuffer) record(r *core.RegionInfo) {
 	h.Lock()
 	defer h.Unlock()
+	if retainIndex, ok := h.minRetainIndexLocked(); ok {
+		window := uint64(0)
+		if h.index+1 > retainIndex {
+			window = h.index + 1 - retainIndex
+		}
+		h.ensureWindowLocked(window)
+	}
 	syncIndexGauge.Set(float64(h.index))
 	h.records[h.tail] = r
 	h.tail = (h.tail + 1) % h.size
@@ -119,6 +174,99 @@ func (h *historyBuffer) recordsFrom(index uint64) []*core.RegionInfo {
 	return records
 }
 
+func (h *historyBuffer) retainFrom(index uint64) *historyRetainer {
+	h.Lock()
+	defer h.Unlock()
+	h.nextRetainID++
+	id := h.nextRetainID
+	h.retains[id] = index
+	if index < h.firstIndex() {
+		h.retainOverflow = true
+	}
+	window := uint64(0)
+	if h.index > index {
+		window = h.index - index
+	}
+	h.ensureWindowLocked(window)
+	return &historyRetainer{h: h, id: id}
+}
+
+func (r *historyRetainer) release() {
+	if r == nil || r.h == nil {
+		return
+	}
+	r.h.releaseRetain(r.id)
+}
+
+func (r *historyRetainer) overflowed() bool {
+	if r == nil || r.h == nil {
+		return false
+	}
+	return r.h.retainOverflowed()
+}
+
+func (h *historyBuffer) releaseRetain(id uint64) {
+	h.Lock()
+	defer h.Unlock()
+	delete(h.retains, id)
+	if len(h.retains) == 0 {
+		h.retainOverflow = false
+	}
+}
+
+func (h *historyBuffer) retainOverflowed() bool {
+	h.RLock()
+	defer h.RUnlock()
+	return h.retainOverflow
+}
+
+func (h *historyBuffer) observeRequiredWindow(window uint64) {
+	h.Lock()
+	defer h.Unlock()
+	h.observeRequiredWindowLocked(window)
+}
+
+func (h *historyBuffer) observeRequiredWindowLocked(window uint64) {
+	if window > h.observedRequiredWindow {
+		h.observedRequiredWindow = window
+	}
+	if window > uint64(h.capacity()/2) {
+		h.growForWindowLocked(window * 2)
+	}
+}
+
+func (h *historyBuffer) maybeShrink() {
+	h.Lock()
+	defer h.Unlock()
+	if len(h.retains) > 0 || h.capacity() <= h.baseCapacity {
+		h.observedRequiredWindow = 0
+		h.lowWindowRounds = 0
+		return
+	}
+	if h.observedRequiredWindow > uint64(h.capacity()/4) {
+		h.observedRequiredWindow = 0
+		h.lowWindowRounds = 0
+		return
+	}
+	h.lowWindowRounds++
+	if h.lowWindowRounds < historyBufferShrinkRounds {
+		h.observedRequiredWindow = 0
+		return
+	}
+	target := h.baseCapacity
+	if h.observedRequiredWindow > 0 {
+		target = normalizeHistoryBufferCapacity(int(h.observedRequiredWindow*2), h.capacityUnit)
+		if target < h.baseCapacity {
+			target = h.baseCapacity
+		}
+	}
+	if target < h.capacity() {
+		h.resizeLocked(target)
+	}
+	h.observedRequiredWindow = 0
+	h.lowWindowRounds = 0
+}
+
 func (h *historyBuffer) resetWithIndex(index uint64) {
 	h.Lock()
 	defer h.Unlock()
@@ -130,6 +278,13 @@ func (h *historyBuffer) resetWithIndexLocked(index uint64) {
 	h.head = 0
 	h.tail = 0
 	h.flushCount = defaultFlushCount
+	h.retains = make(map[uint64]uint64)
+	h.retainOverflow = false
+	h.observedRequiredWindow = 0
+	h.lowWindowRounds = 0
+	if h.capacity() > h.baseCapacity {
+		h.resizeLocked(h.baseCapacity)
+	}
 }
 
 func (h *historyBuffer) resetWithIndexAndPersist(index uint64) {
@@ -154,11 +309,7 @@ func (h *historyBuffer) getFirstIndex() uint64 {
 func (h *historyBuffer) get(index uint64) *core.RegionInfo {
 	h.RLock()
 	defer h.RUnlock()
-	if index < h.nextIndex() && index >= h.firstIndex() {
-		pos := (h.head + int(index-h.firstIndex())) % h.size
-		return h.records[pos]
-	}
-	return nil
+	return h.getLocked(index)
 }
 
 func (h *historyBuffer) reload() {
@@ -182,4 +333,75 @@ func (h *historyBuffer) persist() {
 	if err != nil {
 		log.Warn("persist history index failed", zap.Uint64("persist-index", h.nextIndex()), errs.ZapError(err))
 	}
+}
+
+func (h *historyBuffer) ensureWindowLocked(window uint64) {
+	if window > h.observedRequiredWindow {
+		h.observedRequiredWindow = window
+	}
+	if window <= uint64(h.capacity()) {
+		return
+	}
+	h.growForWindowLocked(window * 2)
+	if window > uint64(h.capacity()) {
+		h.retainOverflow = true
+	}
+}
+
+func (h *historyBuffer) growForWindowLocked(window uint64) {
+	target := normalizeHistoryBufferCapacity(int(window), h.capacityUnit)
+	if target > h.maxCapacity {
+		target = h.maxCapacity
+	}
+	if target > h.capacity() {
+		h.resizeLocked(target)
+	}
+}
+
+func (h *historyBuffer) resizeLocked(newCapacity int) {
+	newCapacity = normalizeHistoryBufferCapacity(newCapacity, h.capacityUnit)
+	if newCapacity < h.baseCapacity {
+		newCapacity = h.baseCapacity
+	}
+	if newCapacity > h.maxCapacity {
+		newCapacity = h.maxCapacity
+	}
+	if newCapacity == h.capacity() {
+		return
+	}
+	keep := h.len()
+	if keep > newCapacity {
+		keep = newCapacity
+	}
+	startIndex := h.index - uint64(keep)
+	records := make([]*core.RegionInfo, newCapacity+1)
+	for i := range keep {
+		records[i] = h.getLocked(startIndex + uint64(i))
+	}
+	h.records = records
+	h.size = newCapacity + 1
+	h.head = 0
+	h.tail = keep % h.size
+}
+
+func (h *historyBuffer) getLocked(index uint64) *core.RegionInfo {
+	if index < h.nextIndex() && index >= h.firstIndex() {
+		pos := (h.head + int(index-h.firstIndex())) % h.size
+		return h.records[pos]
+	}
+	return nil
+}
+
+func (h *historyBuffer) minRetainIndexLocked() (uint64, bool) {
+	var (
+		minIndex uint64
+		ok       bool
+	)
+	for _, index := range h.retains {
+		if !ok || index < minIndex {
+			minIndex = index
+			ok = true
+		}
+	}
+	return minIndex, ok
 }

--- a/pkg/syncer/history_buffer_test.go
+++ b/pkg/syncer/history_buffer_test.go
@@ -19,72 +19,150 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/pingcap/kvproto/pkg/metapb"
-
 	"github.com/tikv/pd/pkg/core"
+	"github.com/tikv/pd/pkg/storage"
 	"github.com/tikv/pd/pkg/storage/kv"
 )
 
-func TestBufferSize(t *testing.T) {
+func TestNormalizeHistoryBufferCapacity(t *testing.T) {
+	testCases := []struct {
+		name     string
+		size     int
+		unit     int
+		expected int
+	}{
+		{name: "below-unit", size: 1, unit: historyBufferCapacityUnit, expected: historyBufferCapacityUnit},
+		{name: "one-unit", size: historyBufferCapacityUnit, unit: historyBufferCapacityUnit, expected: historyBufferCapacityUnit},
+		{name: "round-to-two-units", size: historyBufferCapacityUnit + 1, unit: historyBufferCapacityUnit, expected: 2 * historyBufferCapacityUnit},
+		{name: "round-to-four-units", size: 3 * historyBufferCapacityUnit, unit: historyBufferCapacityUnit, expected: 4 * historyBufferCapacityUnit},
+		{name: "test-unit", size: 3, unit: 1, expected: 4},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			require.Equal(t, testCase.expected, normalizeHistoryBufferCapacity(testCase.size, testCase.unit))
+		})
+	}
+}
+
+func TestHistoryBufferKeepsRingBehaviorWithoutRetain(t *testing.T) {
 	re := require.New(t)
-	var regions []*core.RegionInfo
-	for i := range 101 {
-		regions = append(regions, core.NewRegionInfo(&metapb.Region{Id: uint64(i)}, nil))
+	h := newTestHistoryBuffer(8)
+	h.resetWithIndex(100)
+
+	for i := 1; i <= 3; i++ {
+		h.record(newHistoryBufferTestRegion(uint64(i)))
 	}
 
-	// size equals 1
-	h := newHistoryBuffer(1, kv.NewMemoryKV())
-	re.Equal(0, h.len())
-	for _, r := range regions {
-		h.record(r)
-	}
-	re.Equal(1, h.len())
-	re.Equal(regions[h.nextIndex()-1], h.get(100))
-	re.Nil(h.get(99))
+	re.Equal(2, h.capacity())
+	re.Nil(h.recordsFrom(100))
+	records := h.recordsFrom(101)
+	re.Len(records, 2)
+	re.Equal(uint64(2), records[0].GetID())
+	re.Equal(uint64(3), records[1].GetID())
+}
 
-	// size equals 2
-	h = newHistoryBuffer(2, kv.NewMemoryKV())
-	for _, r := range regions {
-		h.record(r)
-	}
-	re.Equal(2, h.len())
-	re.Equal(regions[h.nextIndex()-1], h.get(100))
-	re.Equal(regions[h.nextIndex()-2], h.get(99))
-	re.Nil(h.get(98))
-
-	// size equals 100
+func TestHistoryBufferPersistsNextIndexOnly(t *testing.T) {
+	re := require.New(t)
 	kvMem := kv.NewMemoryKV()
-	h1 := newHistoryBuffer(100, kvMem)
-	for i := range 6 {
-		h1.record(regions[i])
+	h1 := newHistoryBufferWithConfig(4, 8, 1, kvMem)
+	for i := 1; i <= 3; i++ {
+		h1.record(newHistoryBufferTestRegion(uint64(i)))
 	}
-	re.Equal(6, h1.len())
-	re.Equal(uint64(6), h1.nextIndex())
+	re.Equal(3, h1.len())
 	h1.persist()
 
-	// restart the buffer
-	h2 := newHistoryBuffer(100, kvMem)
-	re.Equal(uint64(6), h2.nextIndex())
-	re.Equal(uint64(6), h2.firstIndex())
-	re.Nil(h2.get(h.nextIndex() - 1))
+	h2 := newHistoryBufferWithConfig(4, 8, 1, kvMem)
+	re.Equal(uint64(3), h2.nextIndex())
+	re.Equal(uint64(3), h2.firstIndex())
 	re.Equal(0, h2.len())
-	for _, r := range regions {
-		index := h2.nextIndex()
-		h2.record(r)
-		re.Equal(r, h2.get(index))
-	}
-
-	re.Equal(uint64(107), h2.nextIndex())
-	re.Nil(h2.get(h2.nextIndex()))
+	re.Nil(h2.get(2))
 	s, err := h2.kv.Load(historyKey)
 	re.NoError(err)
-	// flush in index 106
-	re.Equal("106", s)
+	re.Equal("3", s)
+}
 
-	histories := h2.recordsFrom(uint64(1))
-	re.Empty(histories)
-	histories = h2.recordsFrom(h2.firstIndex())
-	re.Len(histories, 100)
-	re.Equal(uint64(7), h2.firstIndex())
-	re.Equal(regions[1:], histories)
+func TestHistoryBufferRetainGrowsAndPreservesRecords(t *testing.T) {
+	re := require.New(t)
+	h := newTestHistoryBuffer(8)
+	h.resetWithIndex(100)
+
+	retainer := h.retainFrom(100)
+	defer retainer.release()
+	for i := 1; i <= 3; i++ {
+		h.record(newHistoryBufferTestRegion(uint64(i)))
+	}
+
+	re.Equal(8, h.capacity())
+	re.False(retainer.overflowed())
+	records := h.recordsFrom(100)
+	re.Len(records, 3)
+	for i, record := range records {
+		re.Equal(uint64(i+1), record.GetID())
+	}
+}
+
+func TestHistoryBufferMultipleRetainsKeepEarliestIndex(t *testing.T) {
+	re := require.New(t)
+	h := newTestHistoryBuffer(8)
+	h.resetWithIndex(100)
+
+	first := h.retainFrom(100)
+	defer first.release()
+	second := h.retainFrom(101)
+	defer second.release()
+	for i := 1; i <= 3; i++ {
+		h.record(newHistoryBufferTestRegion(uint64(i)))
+	}
+
+	re.False(first.overflowed())
+	re.False(second.overflowed())
+	records := h.recordsFrom(100)
+	re.Len(records, 3)
+}
+
+func TestHistoryBufferRetainOverflowAtMaxCapacity(t *testing.T) {
+	re := require.New(t)
+	h := newTestHistoryBuffer(4)
+	h.resetWithIndex(100)
+
+	retainer := h.retainFrom(100)
+	defer retainer.release()
+	for i := 1; i <= 5; i++ {
+		h.record(newHistoryBufferTestRegion(uint64(i)))
+	}
+
+	re.Equal(4, h.capacity())
+	re.True(retainer.overflowed())
+}
+
+func TestHistoryBufferObserveRequiredWindowGrowsWithoutRetain(t *testing.T) {
+	re := require.New(t)
+	h := newTestHistoryBuffer(8)
+
+	h.observeRequiredWindow(3)
+
+	re.Equal(8, h.capacity())
+}
+
+func TestHistoryBufferShrinksAfterRequiredWindowStaysLow(t *testing.T) {
+	re := require.New(t)
+	h := newTestHistoryBuffer(8)
+	h.observeRequiredWindow(3)
+	re.Equal(8, h.capacity())
+
+	for range historyBufferShrinkRounds + 1 {
+		h.observeRequiredWindow(1)
+		h.maybeShrink()
+	}
+
+	re.Equal(2, h.capacity())
+}
+
+func newTestHistoryBuffer(maxCapacity int) *historyBuffer {
+	return newHistoryBufferWithConfig(2, maxCapacity, 1, storage.NewStorageWithMemoryBackend())
+}
+
+func newHistoryBufferTestRegion(regionID uint64) *core.RegionInfo {
+	return newTestSyncRegion(regionID, regionID+10)
 }

--- a/pkg/syncer/server.go
+++ b/pkg/syncer/server.go
@@ -34,6 +34,7 @@ import (
 
 	"github.com/tikv/pd/pkg/core"
 	"github.com/tikv/pd/pkg/errs"
+	"github.com/tikv/pd/pkg/memory"
 	"github.com/tikv/pd/pkg/ratelimit"
 	"github.com/tikv/pd/pkg/storage"
 	"github.com/tikv/pd/pkg/storage/kv"
@@ -49,6 +50,8 @@ const (
 	maxSyncRegionBatchSize   = 1000
 	syncerKeepAliveInterval  = 10 * time.Second
 	defaultHistoryBufferSize = 10000
+	historyBufferMemoryStep  = 4 * 1024 * 1024 * 1024
+	maxHistoryBufferBaseSize = 80000
 )
 
 // ClientStream is the client side of the region syncer.
@@ -118,15 +121,31 @@ func NewRegionSyncer(s Server) *RegionSyncer {
 	if regionStorage == nil {
 		return nil
 	}
+	historyBufferSize := historyBufferSizeFromMemory(memory.GetMemTotalIgnoreErr())
 	syncer := &RegionSyncer{
 		server:      s,
-		history:     newHistoryBuffer(defaultHistoryBufferSize, regionStorage.(kv.Base)),
+		history:     newHistoryBuffer(historyBufferSize, regionStorage.(kv.Base)),
 		limit:       ratelimit.NewRateLimiter(defaultBucketRate, defaultBucketCapacity),
 		sendTimeout: syncerKeepAliveInterval,
 		tlsConfig:   s.GetTLSConfig(),
 	}
 	syncer.mu.streams = make(map[string]*regionSyncStream)
 	return syncer
+}
+
+func historyBufferSizeFromMemory(totalMemory uint64) int {
+	if totalMemory == 0 {
+		return defaultHistoryBufferSize
+	}
+	size := int(uint64(defaultHistoryBufferSize) * totalMemory / historyBufferMemoryStep)
+	if size < defaultHistoryBufferSize {
+		return defaultHistoryBufferSize
+	}
+	size = normalizeHistoryBufferCapacity(size, historyBufferCapacityUnit)
+	if size > maxHistoryBufferBaseSize {
+		return maxHistoryBufferBaseSize
+	}
+	return size
 }
 
 // RunServer runs the server of the region syncer.
@@ -192,6 +211,7 @@ func (s *RegionSyncer) RunServer(ctx context.Context, regionNotifier <-chan *cor
 			}
 			s.broadcast(ctx, regions)
 		case <-ticker.C:
+			s.history.maybeShrink()
 			alive := &pdpb.SyncRegionResponse{
 				Header:     &pdpb.ResponseHeader{ClusterId: keypath.ClusterID()},
 				StartIndex: s.history.getNextIndex(),
@@ -292,6 +312,10 @@ func (s *RegionSyncer) syncHistoryRegion(ctx context.Context, request *pdpb.Sync
 	if startIndex == 0 {
 		return s.syncFullRegions(ctx, name, stream)
 	}
+	nextIndex := s.history.getNextIndex()
+	if startIndex < nextIndex {
+		s.history.observeRequiredWindow(nextIndex - startIndex)
+	}
 	records := s.history.recordsFrom(startIndex)
 	if len(records) == 0 {
 		if s.history.getNextIndex() == startIndex {
@@ -352,26 +376,33 @@ func (*RegionSyncer) syncHistoryRecords(startIndex uint64, records []*core.Regio
 func (s *RegionSyncer) syncFullRegions(ctx context.Context, name string, stream pdpb.PD_SyncRegionsServer) (*regionSyncStream, error) {
 	for {
 		start := time.Now()
-		catchUpIndex, canceled, err := s.sendFullRegionSnapshot(ctx, stream)
+		catchUpIndex := s.history.getNextIndex()
+		retainer := s.history.retainFrom(catchUpIndex)
+		canceled, err := s.sendFullRegionSnapshot(ctx, stream)
 		if err != nil {
+			retainer.release()
 			return nil, err
 		}
 		if canceled {
+			retainer.release()
 			return nil, nil
 		}
-		catchUpIndex, restart, err := s.catchUpFullSyncHistory(name, catchUpIndex, stream)
+		catchUpIndex, restart, err := s.catchUpFullSyncHistory(name, catchUpIndex, stream, retainer)
 		if err != nil {
+			retainer.release()
 			return nil, err
 		}
 		if restart {
+			retainer.release()
 			continue
 		}
-		return s.completeFullSyncAndBindStream(name, stream, catchUpIndex, start)
+		syncStream, err := s.completeFullSyncAndBindStream(name, stream, catchUpIndex, start, retainer)
+		retainer.release()
+		return syncStream, err
 	}
 }
 
-func (s *RegionSyncer) sendFullRegionSnapshot(ctx context.Context, stream pdpb.PD_SyncRegionsServer) (uint64, bool, error) {
-	catchUpIndex := s.history.getNextIndex()
+func (s *RegionSyncer) sendFullRegionSnapshot(ctx context.Context, stream pdpb.PD_SyncRegionsServer) (bool, error) {
 	regions := s.server.GetRegions()
 	if len(regions) == 0 {
 		resp := &pdpb.SyncRegionResponse{
@@ -380,7 +411,7 @@ func (s *RegionSyncer) sendFullRegionSnapshot(ctx context.Context, stream pdpb.P
 		}
 		if err := stream.Send(resp); err != nil {
 			log.Warn("failed to send sync region response", errs.ZapError(errs.ErrGRPCSend, err))
-			return 0, false, err
+			return false, err
 		}
 	}
 	lastIndex := 0
@@ -395,7 +426,7 @@ func (s *RegionSyncer) sendFullRegionSnapshot(ctx context.Context, stream pdpb.P
 			failpoint.Inject("noFastExitSync", func() {
 				failpoint.Goto("doSync")
 			})
-			return 0, true, nil
+			return true, nil
 		default:
 		}
 		failpoint.Label("doSync")
@@ -424,27 +455,31 @@ func (s *RegionSyncer) sendFullRegionSnapshot(ctx context.Context, stream pdpb.P
 		}
 		if err := s.limit.WaitN(ctx, resp.Size()); err != nil {
 			log.Error("failed to wait rate limit", errs.ZapError(err))
-			return 0, false, err
+			return false, err
 		}
 		lastIndex += len(metas)
 		if err := stream.Send(resp); err != nil {
 			log.Error("failed to send sync region response", errs.ZapError(errs.ErrGRPCSend, err))
-			return 0, false, err
+			return false, err
 		}
 		metas = metas[:0]
 		stats = stats[:0]
 		leaders = leaders[:0]
 		buckets = buckets[:0]
 	}
-	return catchUpIndex, false, nil
+	return false, nil
 }
 
 func (s *RegionSyncer) catchUpFullSyncHistory(
 	name string,
 	catchUpIndex uint64,
 	stream pdpb.PD_SyncRegionsServer,
+	retainer *historyRetainer,
 ) (uint64, bool, error) {
 	for {
+		if retainer.overflowed() {
+			return 0, false, errHistoryBufferRetainOverflow
+		}
 		records := s.history.recordsFrom(catchUpIndex)
 		if len(records) == 0 {
 			if catchUpIndex < s.history.getFirstIndex() {
@@ -473,11 +508,15 @@ func (s *RegionSyncer) completeFullSyncAndBindStream(
 	stream pdpb.PD_SyncRegionsServer,
 	catchUpIndex uint64,
 	start time.Time,
+	retainer *historyRetainer,
 ) (*regionSyncStream, error) {
 	syncStream := newRegionSyncStream(stream)
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	for {
+		if retainer.overflowed() {
+			return nil, errHistoryBufferRetainOverflow
+		}
 		records := s.history.recordsFrom(catchUpIndex)
 		if len(records) == 0 {
 			if catchUpIndex < s.history.getFirstIndex() {

--- a/pkg/syncer/server_test.go
+++ b/pkg/syncer/server_test.go
@@ -37,6 +37,26 @@ import (
 	"github.com/tikv/pd/pkg/utils/testutil"
 )
 
+func TestHistoryBufferSizeFromMemory(t *testing.T) {
+	testCases := []struct {
+		name        string
+		totalMemory uint64
+		expected    int
+	}{
+		{name: "zero-memory", totalMemory: 0, expected: defaultHistoryBufferSize},
+		{name: "below-minimum", totalMemory: historyBufferMemoryStep / 2, expected: defaultHistoryBufferSize},
+		{name: "base-step", totalMemory: historyBufferMemoryStep, expected: defaultHistoryBufferSize},
+		{name: "round-to-two-units", totalMemory: historyBufferMemoryStep * 3 / 2, expected: 2 * defaultHistoryBufferSize},
+		{name: "max-clamped", totalMemory: historyBufferMemoryStep * 64 / 4, expected: maxHistoryBufferBaseSize},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			require.Equal(t, testCase.expected, historyBufferSizeFromMemory(testCase.totalMemory))
+		})
+	}
+}
+
 func TestSyncExitsWhenRegionSyncerStops(t *testing.T) {
 	re := require.New(t)
 	tempDir := t.TempDir()
@@ -372,10 +392,10 @@ func TestSyncFallsBackToFullSyncWhenHistoryMissing(t *testing.T) {
 	waitTestRegionSyncerUnavailable(re, done)
 }
 
-func TestFullSyncRestartsWhenHistoryBufferOverflowsDuringCatchUp(t *testing.T) {
+func TestFullSyncGrowsHistoryBufferDuringCatchUp(t *testing.T) {
 	re := require.New(t)
 	syncer, bc := newTestRegionSyncer(t, newTestSyncRegion(1, 11))
-	syncer.history = newHistoryBuffer(1, syncer.history.kv)
+	syncer.history = newHistoryBufferWithConfig(1, 4, 1, syncer.history.kv)
 	syncer.history.resetWithIndex(100)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -399,22 +419,64 @@ func TestFullSyncRestartsWhenHistoryBufferOverflowsDuringCatchUp(t *testing.T) {
 	re.Len(resp.GetRegions(), 1)
 	re.Equal(uint64(1), resp.GetRegions()[0].GetId())
 
-	resp = mustRecvSyncRegionResponse(t, stream, "expected restarted full sync response")
-	re.Equal(uint64(0), resp.GetStartIndex())
-	re.Len(resp.GetRegions(), 3)
+	resp = mustRecvSyncRegionResponse(t, stream, "expected full sync catch-up response")
+	re.Equal(uint64(100), resp.GetStartIndex())
+	re.Len(resp.GetRegions(), 2)
 	regionIDs := make([]uint64, 0, len(resp.GetRegions()))
 	for _, region := range resp.GetRegions() {
 		regionIDs = append(regionIDs, region.GetId())
 	}
-	re.ElementsMatch([]uint64{1, 2, 3}, regionIDs)
+	re.ElementsMatch([]uint64{2, 3}, regionIDs)
 
 	resp = mustRecvSyncRegionResponse(t, stream, "expected full sync completion response")
 	re.Equal(uint64(102), resp.GetStartIndex())
 	re.Empty(resp.GetRegions())
+	re.Equal(4, syncer.history.capacity())
 	waitTestRegionSyncerBound(re, syncer)
 
 	cancel()
 	waitTestRegionSyncerUnavailable(re, done)
+}
+
+func TestFullSyncFailsWhenRetainedHistoryExceedsMaxCapacity(t *testing.T) {
+	re := require.New(t)
+	syncer, bc := newTestRegionSyncer(t, newTestSyncRegion(1, 11))
+	syncer.history = newHistoryBufferWithConfig(1, 1, 1, syncer.history.kv)
+	syncer.history.resetWithIndex(100)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	stream := newMockSyncRegionsServer()
+	blockCh := stream.blockSend()
+	done := startTestRegionSync(ctx, syncer, stream)
+
+	sendTestSyncRegionRequest(stream, 1)
+	testutil.Eventually(re, stream.isSendBlocked)
+	for _, region := range []*core.RegionInfo{
+		newTestSyncRegion(2, 12),
+		newTestSyncRegion(3, 13),
+	} {
+		bc.PutRegion(region)
+		syncer.history.record(region)
+	}
+	close(blockCh)
+
+	resp := mustRecvSyncRegionResponse(t, stream, "expected original full sync response")
+	re.Equal(uint64(0), resp.GetStartIndex())
+	re.Len(resp.GetRegions(), 1)
+	re.Equal(uint64(1), resp.GetRegions()[0].GetId())
+
+	var syncErr error
+	testutil.Eventually(re, func() bool {
+		if syncErr == nil {
+			select {
+			case syncErr = <-done:
+			default:
+				return false
+			}
+		}
+		return errors.Is(syncErr, errHistoryBufferRetainOverflow)
+	})
+	re.Empty(syncer.GetAllDownstreamNames())
 }
 
 func TestClientWaitsForFullSyncCompletionBeforeRunning(t *testing.T) {


### PR DESCRIPTION
## What problem does this PR solve?

Ref tikv/pd#10711.

This is a stacked draft on top of tikv/pd#10689. It should be rebased and opened against tikv/pd:master after #10689 is merged.

## What is changed and how does it work?

This PR makes the region syncer history buffer resize based on the required replay window instead of relying on a fixed capacity.

- Keeps production capacity in `2^n * 10000` units.
- Sizes the base capacity from visible memory, with a conservative base cap.
- Lets the buffer grow up to `base * 8` when the observed replay window requires it.
- Tracks full-sync retain windows so catch-up history is not silently overwritten while a follower is receiving the full snapshot.
- Shrinks back toward the base capacity only when there is no active retain and the observed required window stays low.
- Fails the current full-sync attempt explicitly if the retained history range exceeds the maximum capacity, so follower local reads do not become enabled from an incomplete sync.

## Check List

- Unit test

## Tests

- `make gotest GOTEST_ARGS='./pkg/syncer -count=1'`
- `make static PACKAGE_DIRECTORIES='./pkg/syncer'`
- `git diff --check`

## Release note

```release-note
None
```